### PR TITLE
[4.5.2] PRFT-6381 - There's no backlighting for PDF preview's elements

### DIFF
--- a/index.css
+++ b/index.css
@@ -29,7 +29,7 @@
     background: #444;
 }
 
-.littleGallery .littleGallery-head .littleGallery-img-activ {
+.littleGallery .littleGallery-head .littleGallery-img-active {
     background: #444;
 }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Project test suite passes: unknown
Fixed issue: https://jira.opensoftdev.com/browse/PRFT-6381
